### PR TITLE
Support for newer VC 2012 & 2013 redists (e.g. 11.0.61135 & 12.0.40664)

### DIFF
--- a/Universal Updater/Program.cs
+++ b/Universal Updater/Program.cs
@@ -946,12 +946,16 @@ namespace Universal_Updater
 
             logFile = prepareLogFile("universal_updater.exe");
 
-            if (!IsDependenciesInstalled("Microsoft Visual C++ 2012 Redistributable (x86)"))
+            if ((!IsDependenciesInstalled("Microsoft Visual C++ 2012 Redistributable (x86)")) &&
+                ((!IsDependenciesInstalled("Microsoft Visual C++ 2012 x86 Minimum Runtime")) ||
+                 (!IsDependenciesInstalled("Microsoft Visual C++ 2012 x86 Additional Runtime"))))
             {
                 WriteLine("Error:\n  An assembly in the application dependencies manifest was not found:\n    package: 'Microsoft.Visual.C++.2012.Redistributable.(x86)'", ConsoleColor.Red);
                 allowToRun = false;
             }
-            else if (!IsDependenciesInstalled("Microsoft Visual C++ 2013 Redistributable (x86)"))
+            else if ((!IsDependenciesInstalled("Microsoft Visual C++ 2013 Redistributable (x86)"))
+                     ((!IsDependenciesInstalled("Microsoft Visual C++ 2013 x86 Minimum Runtime")) ||
+                      (!IsDependenciesInstalled("Microsoft Visual C++ 2013 x86 Additional Runtime"))))
             {
                 WriteLine("Error:\n  An assembly in the application dependencies manifest was not found:\n    package: 'Microsoft.Visual.C++.2013.Redistributable.(x86)'", ConsoleColor.Red);
                 allowToRun = false;


### PR DESCRIPTION
Newer Visual C++ 2012 and 2013 redistributables give split entries in the installed programs list, namely “Microsoft Visual C++ 2012/2013 x86/x64 Minimum Runtime” and “Microsoft Visual C++ 2012/2013 x86/x64 Additional Runtime”.

![image](https://github.com/user-attachments/assets/b6da2ed3-29cc-4f75-ac6c-50adddd981cf)

This program did not detect the newer VC 2012 and 2013 redists and threw errors in current versions prior to this PR. This PR adds support for such redists; Tested working for VC 2012 redist version 11.0.61135 and VC 2013 redist version 12.0.40664.